### PR TITLE
add line-only -l flag, to add line graph of median values.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@ int main(int argc, char* argv[])
     options.use_db_scale,
     options.db_min,
     options.db_max,
+    options.line_only,
     progress_callback
   );
   cerr << endl;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -39,6 +39,8 @@ struct Options
 		    ("db-max", po::value(&db_max)->default_value(0.0f),
     			"maximum value of the signal in dB, that will be visible in the waveform. "
     			"Usefull, if you now, that your signal peaks at a certain level.")
+    		("line-only,l", po::value(&line_only)->zero_tokens()->default_value(false), 
+          		"do a line only (no fill)")
     	;
 
     	po::options_description hidden("Hidden options");
@@ -198,6 +200,8 @@ struct Options
 	bool use_db_scale;
 	float db_min;
 	float db_max;
+
+	bool line_only;
 };
 
 #endif /* OPTIONS_HPP__ */

--- a/src/wav2png.cpp
+++ b/src/wav2png.cpp
@@ -124,7 +124,7 @@ void compute_waveform(
     for each vertical pixel in the image (x), read frames_per_pixel frames from
     the audio file and find the min and max values.
   */
-  size_t y_median_last;
+  size_t y_median_last = 0;
   for (size_t x = 0; x < image.get_width(); ++x)
   {
     // read frames

--- a/src/wav2png.hpp
+++ b/src/wav2png.hpp
@@ -15,5 +15,6 @@ void compute_waveform(
   bool use_db_scale,
   float db_min,
   float db_max,
+  bool line_only,
   progress_callback_t progress_callback
 );


### PR DESCRIPTION
Hi.

Thanks for the nice tool and excellent code.

This commit adds a -l / --line-only flag which changes the drawn figure to a line graph of the median value of each block, rather than a "filled in" curve. The default remains the current draw style.

regards,

jb