### PR TITLE
ignore warning for unused-local-typedefs

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -41,7 +41,7 @@ $(SRC)/version.hpp: Makefile version.txt
 $(BINARY): $(SRC)/*.cpp $(SRC)/*.hpp $(SRC)/version.hpp
 	mkdir -p `dirname $(BINARY)`
 	echo $(INCLUDES)
-	$(CC) -O3 -Wall -Werror $(SRC)/*.cpp $(INCLUDES) $(LD_PLATFORM_FLAGS) -o $(BINARY)
+	$(CC) -O3 -Wall -Werror -Wno-unused-local-typedefs $(SRC)/*.cpp $(INCLUDES) $(LD_PLATFORM_FLAGS) -o $(BINARY)
 
 clean:
 	rm -f $(BINARY)


### PR DESCRIPTION
I could not compile wav2png on Ubuntu 14.04 with libboost-1.54.0 and gcc-4.8.

Boost versions prior to 1.56.0 had an error that triggered warnings on gcc-4.8, which triggers errorswhen compiling wav2png due to the `-Werror` flag: [https://svn.boost.org/trac/boost/ticket/9415](https://svn.boost.org/trac/boost/ticket/9415)

This pull request ignores this specific warning for `make $(BINARY)` but leaves `make profile` as is.

